### PR TITLE
Supports JC-PS201U

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ build
 # other
 eclipse
 run
+lib

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ disableJInput=true
 - RealTrainMod: 1.7.10.40
 - ATSAssist: 1.4.1beta_v4.0
 
+---
 
 - USBゲームパッドコンバータ: 
   - JC-PS201U
@@ -55,12 +56,37 @@ disableJInput=true
 - 以上です
 
 ## 各ボタン機能対照表
-※JC-PS201Uはボタン情報が不明なため未実装
+
 | コンバーター/コントローラー | 警笛 | 右ドア | 左ドア |
 | -- | -- | -- | -- |
 | JC-PS101U | A | START | SELECT |
-| JC-PS201U | -- | -- | -- |
+| JC-PS201U | A | START | SELECT |
 | OHC-PC01 | 手前の黒ボタン | 白ボタン | 黄色ボタン |
+
+## ビルド
+
+`lib` ディレクトリを作成し、
+
+- [RTM1.7.10.40_Forge10.13.4.1558.jar](https://www.curseforge.com/minecraft/mc-mods/realtrainmod/files/2940834)
+- [ATSAssistMod1.4.1b_v4.0.jar](https://github.com/Kai-Z-JP/ATSAssistMod/releases)
+
+を `lib` ディレクトリに入れてください。
+
+### Windows
+
+```shell
+.\gradlew.bat setupDecompWorkspace
+.\gradlew.bat idea genIntellijRuns
+.\gradlew.bat build
+```
+
+### Linux
+
+```shell
+./gradlew setupDecompWorkspace
+./gradlew idea genIntellijRuns
+./gradlew build
+```
 
 ## ライセンス
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ disableJInput=true
 - Minecraft: 1.7.10
 - Forge: Forge-10.13.4.1614
 - RealTrainMod: 1.7.10.40
-- ATSAssist: 1.4.1beta_v4.0
+- ATSAssist: 1.4.1beta_v8.3 又は ATSAssistSimple: 3.0
 
 ---
 
@@ -68,7 +68,7 @@ disableJInput=true
 `lib` ディレクトリを作成し、
 
 - [RTM1.7.10.40_Forge10.13.4.1558.jar](https://www.curseforge.com/minecraft/mc-mods/realtrainmod/files/2940834)
-- [ATSAssistMod1.4.1b_v4.0.jar](https://github.com/Kai-Z-JP/ATSAssistMod/releases)
+- [ATSAssistMod_Simple3.0.jar](https://github.com/Kai-Z-JP/ATSAssistModSimple/releases/tag/Simple3.0)
 
 を `lib` ディレクトリに入れてください。
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
 apply plugin: 'forge'
 //Only edit below this line, the above code adds and enables the necessary things for Forge to be setup.
 
-version = "0.1"
+version = "0.2"
 group = "jp.kaiz.rtmdengoadapter" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "rtmdengoadapter"
 

--- a/src/main/java/jp/kaiz/rtmdengoadapter/DPadAsButtonGamePadAdapter.java
+++ b/src/main/java/jp/kaiz/rtmdengoadapter/DPadAsButtonGamePadAdapter.java
@@ -6,17 +6,17 @@ public class DPadAsButtonGamePadAdapter extends GamePadAdapter {
 
     @Override
     public boolean isHorn(Controller control) {
-        return false;
+        return control.isButtonPressed(3);
     }
 
     @Override
     public boolean isDoorR(Controller control) {
-        return false;
+        return control.isButtonPressed(8);
     }
 
     @Override
     public boolean isDoorL(Controller control) {
-        return false;
+        return control.isButtonPressed(9);
     }
 
     public int getNotch(Controller control, int lastNotchLevel) {

--- a/src/main/java/jp/kaiz/rtmdengoadapter/GamePad.java
+++ b/src/main/java/jp/kaiz/rtmdengoadapter/GamePad.java
@@ -5,7 +5,6 @@ import cpw.mods.fml.common.gameevent.TickEvent;
 import jp.kaiz.atsassistmod.api.ControlTrain;
 import jp.ngt.rtm.RTMCore;
 import jp.ngt.rtm.entity.train.EntityTrainBase;
-import jp.ngt.rtm.entity.train.util.TrainState;
 import jp.ngt.rtm.event.RTMKeyHandlerClient;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.Entity;


### PR DESCRIPTION
はじめまして。[RTMDengoAdapter](https://github.com/wakamesoba98/rtmdengoadapter) 作者のわかめそばです。
RealTrainMod 1.7.10 向けの Fork を拝見させて頂きました。キャリブレーションが不要になる、大変素晴らしい実装であると思います。

こちらの Pull Request では RTMDengoAdapter for 1.7.10 を JC-PS201U のキーマップに対応させます。
Minecraft 1.7.10 + JC-PS201U にて動作確認済みとなっています。

加えて、README に簡単なビルド手順を追加しています。
ATSAssistなどライブラリの追加手順などに相違がございましたらコメント頂ければと思います。

どうぞよろしくお願い致します。